### PR TITLE
Switch order of scripts. Fixes #5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication",
-            "EuF\\Nutshell\\Composer\\ScriptHandler::initializeNutshell"
+            "EuF\\Nutshell\\Composer\\ScriptHandler::initializeNutshell",
+            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication",
-            "EuF\\Nutshell\\Composer\\ScriptHandler::initializeNutshell"
+            "EuF\\Nutshell\\Composer\\ScriptHandler::initializeNutshell",
+            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
         ]
     }
 }


### PR DESCRIPTION
See #5.
I changed the order of the scripts in the composer.json, so that the nutshell will be initialized prior Contao creates the symlinks.

Tested:
![screen shot 2018-01-27 at 18 42 28](https://user-images.githubusercontent.com/1284725/35474780-42f21e86-0393-11e8-9ff2-77c1644e9582.png)
